### PR TITLE
Only grab files that END in .py.

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -26,7 +26,7 @@ def system(*args, **kwargs):
 
 
 def main():
-    modified = re.compile('^[AM]+\s+(?P<name>.*\.py)', re.MULTILINE)
+    modified = re.compile('^[AM]+\s+(?P<name>.*\.py$)', re.MULTILINE)
     files = system('git', 'status', '--porcelain').decode("utf-8")
     files = modified.findall(files)
 


### PR DESCRIPTION
Previously, the regex that finds which files to run pep8 over grabbed any file that contained .py (even if that filename was just `.py` or `.pylintrc`), and did not capture any part of the filename that came **after** `.py`. This means, for files like `.pylintrc`, the regex would match, but would only capture `.py` and when we went to run `git show` on it, it failed miserably. Fixes that with a simple anchor.

To reproduce the error: add a `.pylintrc` to your project, add that to the working index and run the commit hook, it will error out with this:

```
fatal: ambiguous argument ':.py': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
