### PR TITLE
Fix modified detection

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -26,7 +26,7 @@ def system(*args, **kwargs):
 
 
 def main():
-    modified = re.compile('^[AM]+\s+(?P<name>.*\.py$)', re.MULTILINE)
+    modified = re.compile('^[ AM]+\s+(?P<name>.*\.py$)', re.MULTILINE)
     files = system('git', 'status', '--porcelain').decode("utf-8")
     files = modified.findall(files)
 


### PR DESCRIPTION
When running git status --porcelain on my machine (macOS, git: 2.18) the modified results looks like this:
" M FileName.py" (without the quotes) 
The above regex doen't handle it and return empty file list